### PR TITLE
Set unknownSize to 1 for the default MessageSizeEstimator

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultMessageSizeEstimator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMessageSizeEstimator.java
@@ -49,7 +49,7 @@ public final class DefaultMessageSizeEstimator implements MessageSizeEstimator {
     /**
      * Return the default implementation which returns {@code -1} for unknown messages.
      */
-    public static final MessageSizeEstimator DEFAULT = new DefaultMessageSizeEstimator(0);
+    public static final MessageSizeEstimator DEFAULT = new DefaultMessageSizeEstimator(1);
 
     private final Handle handle;
 


### PR DESCRIPTION
A default MessageSizeEstimator with unknownSize 1 would prevent OOM on client on channels with slow consumers.
